### PR TITLE
Refactoring and publish plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Java/Kotlin lightweight implementation of RFC-6238 and RFC-4226 to generate and 
 
 ## Maven / gradle dependency
 
-Check the latest package at [https://github.com/atlassian-labs/1time/packages/](https://github.com/atlassian-labs/1time/packages/)
+Check the latest package at [https://github.com/atlassian/1time/packages/](https://github.com/atlassian/1time/packages/)
 
 ## Quick start
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@
 plugins {
   kotlin("jvm") version "1.8.10"
   id("org.jetbrains.dokka") version "1.7.20"
-  id("com.jfrog.artifactory") version "4.31.4"
   id("maven-publish")
   id("signing")
   application
@@ -58,10 +57,10 @@ tasks {
           packaging = "jar"
           name.set(project.name)
           description.set("TOTP and HOTP generator and validator for multi-factor authentication")
-          url.set("https://github.com/atlassian-labs/1time")
+          url.set("https://github.com/atlassian/1time")
           scm {
-            connection.set("git@github.com:atlassian-labs/1time.git")
-            url.set("https://github.com/atlassian-labs/1time.git")
+            connection.set("git@github.com:atlassian/1time.git")
+            url.set("https://github.com/atlassian/1time.git")
           }
           developers {
             developer {
@@ -80,6 +79,16 @@ tasks {
         }
       }
     }
+
+    repositories {
+      maven {
+        url = uri("https://packages.atlassian.com/maven-central")
+        credentials {
+          username = System.getenv("ARTIFACTORY_USERNAME")
+          password = System.getenv("ARTIFACTORY_API_KEY")
+        }
+      }
+    }
   }
 
   signing {
@@ -88,22 +97,5 @@ tasks {
       System.getenv("SIGNING_PASSWORD"),
     )
     sign(publishing.publications["release"])
-  }
-}
-
-artifactory {
-  publish {
-    setContextUrl("https://packages.atlassian.com/")
-
-    repository {
-      setRepoKey("maven-central")
-      setUsername(System.getenv("ARTIFACTORY_USERNAME"))
-      setPassword(System.getenv("ARTIFACTORY_API_KEY"))
-    }
-    defaults {
-      publications("release")
-      setPublishIvy(false)
-      clientConfig.publisher.isPublishBuildInfo = false
-    }
   }
 }


### PR DESCRIPTION
- Refactoring links to remove `-labs` suffix
- Removing artifactory publishing plugin in favor of standard Maven publish plugin