### PR TITLE
Removing coroutines

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,6 @@ tasks.withType<KotlinCompile> {
       "-progressive",
       "-java-parameters",
       "-opt-in=kotlin.time.ExperimentalTime",
-      "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
       "-opt-in=kotlin.RequiresOptIn"
     )
 

--- a/src/main/kotlin/com/atlassian/onetime/service/SecretProvider.kt
+++ b/src/main/kotlin/com/atlassian/onetime/service/SecretProvider.kt
@@ -4,7 +4,7 @@ import com.atlassian.onetime.model.TOTPSecret
 import java.security.SecureRandom
 
 fun interface SecretProvider {
-  suspend fun generateSecret(): TOTPSecret
+  fun generateSecret(): TOTPSecret
 }
 
 class AsciiRangeSecretProvider : SecretProvider {
@@ -13,14 +13,14 @@ class AsciiRangeSecretProvider : SecretProvider {
     val ASCII_RANGE: CharRange = (' '..'z')
   }
 
-  override suspend fun generateSecret() = TOTPSecret(
+  override fun generateSecret() = TOTPSecret(
     (1..20).map { ASCII_RANGE.random() }.joinToString("").toByteArray()
   )
 }
 
 class RandomSecretProvider : SecretProvider {
 
-  override suspend fun generateSecret() =
+  override fun generateSecret() =
     SecureRandom().let {
       val byteArray = ByteArray(20)
       it.nextBytes(byteArray)

--- a/src/main/kotlin/com/atlassian/onetime/service/TOTPService.kt
+++ b/src/main/kotlin/com/atlassian/onetime/service/TOTPService.kt
@@ -10,15 +10,15 @@ import java.net.URLEncoder
 
 interface TOTPService {
 
-  suspend fun generateTotpSecret(): TOTPSecret
+  fun generateTotpSecret(): TOTPSecret
 
-  suspend fun generateTOTPUrl(
+  fun generateTOTPUrl(
     totpSecret: TOTPSecret,
     emailAddress: EmailAddress,
     issuer: Issuer
   ): URI
 
-  suspend fun verify(
+  fun verify(
     code: TOTP,
     totpSecret: TOTPSecret
   ): TOTPVerificationResult
@@ -49,9 +49,9 @@ class DefaultTOTPService(
     private const val DIGITS_QUERY_PARAM = "digits"
     private const val PERIOD_QUERY_PARAM = "period"
   }
-  override suspend fun generateTotpSecret(): TOTPSecret = totpConfiguration.secretProvider.generateSecret()
+  override fun generateTotpSecret(): TOTPSecret = totpConfiguration.secretProvider.generateSecret()
 
-  override suspend fun generateTOTPUrl(
+  override fun generateTOTPUrl(
     totpSecret: TOTPSecret,
     emailAddress: EmailAddress,
     issuer: Issuer
@@ -67,7 +67,7 @@ class DefaultTOTPService(
     return URI(template)
   }
 
-  override suspend fun verify(
+  override fun verify(
     code: TOTP,
     totpSecret: TOTPSecret
   ): TOTPVerificationResult {

--- a/src/test/kotlin/com/atlassian/onetime/core/HOTPGeneratorTest.kt
+++ b/src/test/kotlin/com/atlassian/onetime/core/HOTPGeneratorTest.kt
@@ -127,7 +127,7 @@ class HOTPGeneratorTest : FunSpec() {
     }
   }
 
-  private suspend fun given(state: TestState = TestState(), test: suspend TestState.(HOTPGenerator) -> Unit) {
+  private fun given(state: TestState = TestState(), test: TestState.(HOTPGenerator) -> Unit) {
     with(state) {
       test(state.hotpGenerator)
     }

--- a/src/test/kotlin/com/atlassian/onetime/core/TOTPGeneratorTest.kt
+++ b/src/test/kotlin/com/atlassian/onetime/core/TOTPGeneratorTest.kt
@@ -118,7 +118,7 @@ class TOTPGeneratorTest : FunSpec() {
     }
   }
 
-  private suspend fun given(state: TestState = TestState(), test: suspend TestState.(TOTPGenerator) -> Unit) {
+  private fun given(state: TestState = TestState(), test: TestState.(TOTPGenerator) -> Unit) {
     with(state) {
       test(state.totpGenerator)
     }

--- a/src/test/kotlin/com/atlassian/onetime/service/DefaultTOTPServiceTest.kt
+++ b/src/test/kotlin/com/atlassian/onetime/service/DefaultTOTPServiceTest.kt
@@ -251,7 +251,7 @@ class DefaultTOTPServiceTest : FunSpec({
   }
 })
 
-private suspend fun given(state: TestState = TestState(), test: suspend TestState.(DefaultTOTPService) -> Unit) {
+private fun given(state: TestState = TestState(), test: TestState.(DefaultTOTPService) -> Unit) {
   with(state) {
     test(state.defaultTOTPService)
   }


### PR DESCRIPTION
1time is unnecessarily using suspend functions, which makes the usage from Java pretty clunkly. 
This PR removes all suspend functions from 1time.