### PR TITLE
Adding isFailure and isSuccess attributes to result

### DIFF
--- a/src/main/kotlin/com/atlassian/onetime/model/TOTPSecret.kt
+++ b/src/main/kotlin/com/atlassian/onetime/model/TOTPSecret.kt
@@ -12,9 +12,7 @@ data class TOTPSecret(val value: ByteArray) {
 
     other as TOTPSecret
 
-    if (!value.contentEquals(other.value)) return false
-
-    return true
+    return value.contentEquals(other.value)
   }
 
   override fun hashCode(): Int {

--- a/src/main/kotlin/com/atlassian/onetime/service/TOTPService.kt
+++ b/src/main/kotlin/com/atlassian/onetime/service/TOTPService.kt
@@ -31,8 +31,20 @@ data class TOTPConfiguration(
 )
 
 sealed class TOTPVerificationResult {
-  object InvalidTotp : TOTPVerificationResult()
-  data class Success(val index: Int) : TOTPVerificationResult()
+
+  abstract val isSuccess: Boolean
+  val isFailure: Boolean
+    get() = !this.isSuccess
+
+  object InvalidTotp : TOTPVerificationResult() {
+    override val isSuccess: Boolean
+      get() = false
+  }
+
+  data class Success(val index: Int) : TOTPVerificationResult() {
+    override val isSuccess: Boolean
+      get() = true
+  }
 }
 
 class DefaultTOTPService(

--- a/src/main/kotlin/com/atlassian/onetime/service/TOTPService.kt
+++ b/src/main/kotlin/com/atlassian/onetime/service/TOTPService.kt
@@ -7,6 +7,8 @@ import com.atlassian.onetime.model.Issuer
 import com.atlassian.onetime.model.TOTPSecret
 import java.net.URI
 import java.net.URLEncoder
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 interface TOTPService {
 
@@ -31,19 +33,19 @@ data class TOTPConfiguration(
 )
 
 sealed class TOTPVerificationResult {
+  object InvalidTotp : TOTPVerificationResult()
+  data class Success(val index: Int) : TOTPVerificationResult()
 
-  abstract val isSuccess: Boolean
-  val isFailure: Boolean
-    get() = !this.isSuccess
-
-  object InvalidTotp : TOTPVerificationResult() {
-    override val isSuccess: Boolean
-      get() = false
+  @OptIn(ExperimentalContracts::class)
+  fun isSuccess(): Boolean {
+    contract { returns(true) implies (this@TOTPVerificationResult is Success) }
+    return this@TOTPVerificationResult is Success
   }
 
-  data class Success(val index: Int) : TOTPVerificationResult() {
-    override val isSuccess: Boolean
-      get() = true
+  @OptIn(ExperimentalContracts::class)
+  fun isFailure(): Boolean {
+    contract { returns(true) implies (this@TOTPVerificationResult is InvalidTotp) }
+    return this@TOTPVerificationResult is InvalidTotp
   }
 }
 

--- a/src/test/kotlin/com/atlassian/onetime/service/DefaultTOTPServiceTest.kt
+++ b/src/test/kotlin/com/atlassian/onetime/service/DefaultTOTPServiceTest.kt
@@ -131,6 +131,9 @@ class DefaultTOTPServiceTest : FunSpec({
               userInputTotp,
               secret
             )
+
+            verificationResult.isSuccess shouldBe true
+            verificationResult.isFailure shouldBe false
             verificationResult should beInstanceOf<TOTPVerificationResult.Success>()
             (verificationResult as TOTPVerificationResult.Success).run {
               this.index shouldBeInRange (-allowedPastSteps..0)
@@ -181,6 +184,9 @@ class DefaultTOTPServiceTest : FunSpec({
               userInputTotp,
               secret
             )
+
+            verificationResult.isSuccess shouldBe true
+            verificationResult.isFailure shouldBe false
             verificationResult should beInstanceOf<TOTPVerificationResult.Success>()
             (verificationResult as TOTPVerificationResult.Success).run {
               this.index shouldBeInRange (0..allowedFutureSteps)
@@ -226,6 +232,9 @@ class DefaultTOTPServiceTest : FunSpec({
               userInputTotp,
               secret
             )
+
+            verificationResult.isSuccess shouldBe true
+            verificationResult.isFailure shouldBe false
             verificationResult should beInstanceOf<TOTPVerificationResult.Success>()
             (verificationResult as TOTPVerificationResult.Success).run {
               this.index shouldBe 0
@@ -244,6 +253,9 @@ class DefaultTOTPServiceTest : FunSpec({
             TOTP("123456"),
             secret
           )
+
+          verificationResult.isFailure shouldBe true
+          verificationResult.isSuccess shouldBe false
           verificationResult should beInstanceOf<TOTPVerificationResult.InvalidTotp>()
         }
       }

--- a/src/test/kotlin/com/atlassian/onetime/service/DefaultTOTPServiceTest.kt
+++ b/src/test/kotlin/com/atlassian/onetime/service/DefaultTOTPServiceTest.kt
@@ -132,8 +132,8 @@ class DefaultTOTPServiceTest : FunSpec({
               secret
             )
 
-            verificationResult.isSuccess shouldBe true
-            verificationResult.isFailure shouldBe false
+            verificationResult.isSuccess() shouldBe true
+            verificationResult.isFailure() shouldBe false
             verificationResult should beInstanceOf<TOTPVerificationResult.Success>()
             (verificationResult as TOTPVerificationResult.Success).run {
               this.index shouldBeInRange (-allowedPastSteps..0)
@@ -185,8 +185,8 @@ class DefaultTOTPServiceTest : FunSpec({
               secret
             )
 
-            verificationResult.isSuccess shouldBe true
-            verificationResult.isFailure shouldBe false
+            verificationResult.isSuccess() shouldBe true
+            verificationResult.isFailure() shouldBe false
             verificationResult should beInstanceOf<TOTPVerificationResult.Success>()
             (verificationResult as TOTPVerificationResult.Success).run {
               this.index shouldBeInRange (0..allowedFutureSteps)
@@ -233,8 +233,8 @@ class DefaultTOTPServiceTest : FunSpec({
               secret
             )
 
-            verificationResult.isSuccess shouldBe true
-            verificationResult.isFailure shouldBe false
+            verificationResult.isSuccess() shouldBe true
+            verificationResult.isFailure() shouldBe false
             verificationResult should beInstanceOf<TOTPVerificationResult.Success>()
             (verificationResult as TOTPVerificationResult.Success).run {
               this.index shouldBe 0
@@ -254,8 +254,8 @@ class DefaultTOTPServiceTest : FunSpec({
             secret
           )
 
-          verificationResult.isFailure shouldBe true
-          verificationResult.isSuccess shouldBe false
+          verificationResult.isFailure() shouldBe true
+          verificationResult.isSuccess() shouldBe false
           verificationResult should beInstanceOf<TOTPVerificationResult.InvalidTotp>()
         }
       }


### PR DESCRIPTION
Adding these attributes to make result handling easier for both Kotlin and Java.

Now you can do:

```java
if (result.isSuccess()){
  // Valid totp - handle success
  System.out.println("Valid TOTP provided");
} else{
  // Invalid TOTP - handle error
  System.out.println("Invalid TOTP provided");
}
```

Before this change, in Java you would have to do:

```java
if (result instanceof TOTPVerificationResult.Success){
    // Valid totp - handle success
    Integer successIndex = ((TOTPVerificationResult.Success) result).getIndex();
    System.out.printf("Success at %d\n", successIndex );
} else {
    // Invalid TOTP - handle error
    System.out.println("Invalid TOTP provided" );
}
```

Note that if you need to access the index in Java, you'll need to do casting regardless.