### PR TITLE
Run and fix tests for Java 8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,10 @@ tasks {
 
   test {
     useJUnitPlatform()
+    javaLauncher =
+      project.javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(8)
+      }
   }
 
   publishing {

--- a/src/main/kotlin/com/atlassian/onetime/service/TOTPService.kt
+++ b/src/main/kotlin/com/atlassian/onetime/service/TOTPService.kt
@@ -91,7 +91,7 @@ class DefaultTOTPService(
 }
 
 fun String.urlEncode(): String =
-  URLEncoder.encode(this, Charsets.UTF_8)
+  URLEncoder.encode(this, Charsets.UTF_8.name())
     .replace("+", "%20")
     .replace("*", "%2A")
     .replace("%7E", "~")


### PR DESCRIPTION
`URLEncoder.encode(String, Charset)` is only available on Java 10+, so the current implementation fails on Java 8.

This PR lets the tests run on Java 8, and fixes the problem